### PR TITLE
Use `const fn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 categories = ["value-formatting"]
 license = "MIT"
 edition = "2018"
+exclude = ["benches/*", "bench.png", ".github/*"]
 
 [features]
 default = ["simd", "std"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -137,13 +137,12 @@ pub unsafe fn write_u16(n: u16, buf: *mut u8) -> usize {
             2
         }
     } else if n < 10000 {
+        let (a1, a2) = divmod(n, 100);
         if n < 1000 {
-            let (a1, a2) = divmod(n, 100);
             *buf = a1 as u8 + 0x30;
             ptr::copy_nonoverlapping(lookup(a2), buf.add(1), 2);
             3
         } else {
-            let (a1, a2) = divmod(n, 100);
             ptr::copy_nonoverlapping(lookup(a1), buf, 2);
             ptr::copy_nonoverlapping(lookup(a2), buf.add(2), 2);
             4

--- a/src/common.rs
+++ b/src/common.rs
@@ -160,7 +160,7 @@ pub unsafe fn write_u16(n: u16, buf: *mut u8) -> usize {
 
 /// Multiply unsigned 128 bit integers, return upper 128 bits of the result
 #[inline]
-fn u128_mulhi(x: u128, y: u128) -> u128 {
+const fn u128_mulhi(x: u128, y: u128) -> u128 {
     let x_lo = x as u64;
     let x_hi = (x >> 64) as u64;
     let y_lo = y as u64;


### PR DESCRIPTION
This little PR aims to:
* Make `u128_mulhi` a `const` function.
* Move a common line of code before the if.
* Use the `exclude` field in `cargo.toml` to decrease the crate size.